### PR TITLE
Astral Vinery 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     // used to prevent forge config api port from complaining
     modImplementation("com.github.AlphaMode:fakeconfig:master-SNAPSHOT") { exclude(group: "net.fabricmc.fabric-api") }
     modImplementation("com.github.AlphaMode:fakeconfigtoml:master-SNAPSHOT") { exclude(group: "net.fabricmc.fabric-api") }
+
+    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:$rei_version"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:$rei_version"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,9 @@ terraform_wood_api_version=3.1.0
 modmenu_version = 3.2.5
 # LazyDFU - https://modrinth.com/mod/lazydfu/versions
 lazydfu_version = 0.1.2
+
+rei_version = 8.3.588
+
 # Create
 # https://modrinth.com/mod/create-fabric/versions
 create_version = 0.5.0.i-944+1.18.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ fabric_version=0.75.1+1.18.2
 
 
 # Mod Properties
-mod_version = 1.0.1
+mod_version = 1.1.0
 maven_group = com.github.erdragh
 archives_base_name = astralvinery
 

--- a/src/main/java/com/github/erdragh/astralvinery/AstralVinery.java
+++ b/src/main/java/com/github/erdragh/astralvinery/AstralVinery.java
@@ -3,6 +3,9 @@ package com.github.erdragh.astralvinery;
 import net.fabricmc.api.ModInitializer;
 
 public class AstralVinery implements ModInitializer {
+
+    public static final String MODID = "astralvinery";
+
     /**
      * Runs the mod initializer.
      */

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
@@ -4,12 +4,16 @@ import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotCategory
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
 import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelCategory;
 import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelDisplay;
+import com.github.erdragh.astralvinery.compat.rei.wine_press.WinePressCategory;
+import com.github.erdragh.astralvinery.compat.rei.wine_press.WinePressDisplay;
 import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenCategory;
 import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenDisplay;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
+import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
 import me.shedaniel.rei.api.common.util.EntryStacks;
+import me.shedaniel.rei.plugin.common.BuiltinPlugin;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import satisfyu.vinery.recipe.CookingPotRecipe;
@@ -25,10 +29,12 @@ public class AstralVineryClientPlugin implements REIClientPlugin {
         registry.add(new CookingPotCategory());
         registry.add(new FermentationBarrelCategory());
         registry.add(new WoodFiredOvenCategory());
+        registry.add(new WinePressCategory());
 
         registry.addWorkstations(REICategories.COOKING_POT_CATEGORY, EntryStacks.of(ObjectRegistry.COOKING_POT));
         registry.addWorkstations(REICategories.FERMENTATION_BARREL_CATEGORY, EntryStacks.of(ObjectRegistry.FERMENTATION_BARREL));
         registry.addWorkstations(REICategories.WOOD_FIRED_OVEN_CATEGORY, EntryStacks.of(ObjectRegistry.WOOD_FIRED_OVEN));
+        registry.addWorkstations(REICategories.WINE_PRESS_CATEGORY, EntryStacks.of(ObjectRegistry.WINE_PRESS));
     }
 
     @Override
@@ -36,5 +42,6 @@ public class AstralVineryClientPlugin implements REIClientPlugin {
         registry.registerRecipeFiller(CookingPotRecipe.class, VineryRecipeTypes.COOKING_POT_RECIPE_TYPE, CookingPotDisplay::new);
         registry.registerRecipeFiller(FermentationBarrelRecipe.class, VineryRecipeTypes.FERMENTATION_BARREL_RECIPE_TYPE, FermentationBarrelDisplay::new);
         registry.registerRecipeFiller(WoodFiredOvenRecipe.class, VineryRecipeTypes.WOOD_FIRED_OVEN_RECIPE_TYPE, WoodFiredOvenDisplay::new);
+        registry.add(new WinePressDisplay());
     }
 }

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
@@ -11,9 +11,7 @@ import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenD
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
-import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import me.shedaniel.rei.plugin.common.BuiltinPlugin;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import satisfyu.vinery.recipe.CookingPotRecipe;

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
@@ -1,0 +1,30 @@
+package com.github.erdragh.astralvinery.compat.rei;
+
+import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotCategory;
+import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
+import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import satisfyu.vinery.Vinery;
+import satisfyu.vinery.recipe.CookingPotRecipe;
+import satisfyu.vinery.registry.ObjectRegistry;
+import satisfyu.vinery.registry.VineryMaterials;
+import satisfyu.vinery.registry.VineryRecipeTypes;
+
+@Environment(EnvType.CLIENT)
+public class AstralVineryClientPlugin implements REIClientPlugin {
+    @Override
+    public void registerCategories(CategoryRegistry registry) {
+        registry.add(new CookingPotCategory());
+
+        registry.addWorkstations(REICategories.COOKING_POT_CATEGORY, EntryStacks.of(ObjectRegistry.COOKING_POT));
+    }
+
+    @Override
+    public void registerDisplays(DisplayRegistry registry) {
+        registry.registerRecipeFiller(CookingPotRecipe.class, VineryRecipeTypes.COOKING_POT_RECIPE_TYPE, CookingPotDisplay::new);
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
@@ -2,6 +2,8 @@ package com.github.erdragh.astralvinery.compat.rei;
 
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotCategory;
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
+import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelCategory;
+import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelDisplay;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
@@ -10,6 +12,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import satisfyu.vinery.Vinery;
 import satisfyu.vinery.recipe.CookingPotRecipe;
+import satisfyu.vinery.recipe.FermentationBarrelRecipe;
 import satisfyu.vinery.registry.ObjectRegistry;
 import satisfyu.vinery.registry.VineryMaterials;
 import satisfyu.vinery.registry.VineryRecipeTypes;
@@ -19,12 +22,15 @@ public class AstralVineryClientPlugin implements REIClientPlugin {
     @Override
     public void registerCategories(CategoryRegistry registry) {
         registry.add(new CookingPotCategory());
+        registry.add(new FermentationBarrelCategory());
 
         registry.addWorkstations(REICategories.COOKING_POT_CATEGORY, EntryStacks.of(ObjectRegistry.COOKING_POT));
+        registry.addWorkstations(REICategories.FERMENTATION_BARREL_CATEGORY, EntryStacks.of(ObjectRegistry.FERMENTATION_BARREL));
     }
 
     @Override
     public void registerDisplays(DisplayRegistry registry) {
         registry.registerRecipeFiller(CookingPotRecipe.class, VineryRecipeTypes.COOKING_POT_RECIPE_TYPE, CookingPotDisplay::new);
+        registry.registerRecipeFiller(FermentationBarrelRecipe.class, VineryRecipeTypes.FERMENTATION_BARREL_RECIPE_TYPE, FermentationBarrelDisplay::new);
     }
 }

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/AstralVineryClientPlugin.java
@@ -4,17 +4,18 @@ import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotCategory
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
 import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelCategory;
 import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelDisplay;
+import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenCategory;
+import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenDisplay;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import satisfyu.vinery.Vinery;
 import satisfyu.vinery.recipe.CookingPotRecipe;
 import satisfyu.vinery.recipe.FermentationBarrelRecipe;
+import satisfyu.vinery.recipe.WoodFiredOvenRecipe;
 import satisfyu.vinery.registry.ObjectRegistry;
-import satisfyu.vinery.registry.VineryMaterials;
 import satisfyu.vinery.registry.VineryRecipeTypes;
 
 @Environment(EnvType.CLIENT)
@@ -23,14 +24,17 @@ public class AstralVineryClientPlugin implements REIClientPlugin {
     public void registerCategories(CategoryRegistry registry) {
         registry.add(new CookingPotCategory());
         registry.add(new FermentationBarrelCategory());
+        registry.add(new WoodFiredOvenCategory());
 
         registry.addWorkstations(REICategories.COOKING_POT_CATEGORY, EntryStacks.of(ObjectRegistry.COOKING_POT));
         registry.addWorkstations(REICategories.FERMENTATION_BARREL_CATEGORY, EntryStacks.of(ObjectRegistry.FERMENTATION_BARREL));
+        registry.addWorkstations(REICategories.WOOD_FIRED_OVEN_CATEGORY, EntryStacks.of(ObjectRegistry.WOOD_FIRED_OVEN));
     }
 
     @Override
     public void registerDisplays(DisplayRegistry registry) {
         registry.registerRecipeFiller(CookingPotRecipe.class, VineryRecipeTypes.COOKING_POT_RECIPE_TYPE, CookingPotDisplay::new);
         registry.registerRecipeFiller(FermentationBarrelRecipe.class, VineryRecipeTypes.FERMENTATION_BARREL_RECIPE_TYPE, FermentationBarrelDisplay::new);
+        registry.registerRecipeFiller(WoodFiredOvenRecipe.class, VineryRecipeTypes.WOOD_FIRED_OVEN_RECIPE_TYPE, WoodFiredOvenDisplay::new);
     }
 }

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
@@ -3,6 +3,7 @@ package com.github.erdragh.astralvinery.compat.rei;
 import com.github.erdragh.astralvinery.AstralVinery;
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
 import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelDisplay;
+import com.github.erdragh.astralvinery.compat.rei.wine_press.WinePressDisplay;
 import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenDisplay;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import net.minecraft.util.Identifier;
@@ -11,4 +12,5 @@ public class REICategories {
     public static final CategoryIdentifier<CookingPotDisplay> COOKING_POT_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "cooking_pot"));
     public static final CategoryIdentifier<FermentationBarrelDisplay> FERMENTATION_BARREL_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "fermentation_barrel"));
     public static final CategoryIdentifier<WoodFiredOvenDisplay> WOOD_FIRED_OVEN_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "wood_fired_oven"));
+    public static final CategoryIdentifier<WinePressDisplay> WINE_PRESS_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "wine_press"));
 }

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
@@ -2,9 +2,11 @@ package com.github.erdragh.astralvinery.compat.rei;
 
 import com.github.erdragh.astralvinery.AstralVinery;
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
+import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelDisplay;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import net.minecraft.util.Identifier;
 
 public class REICategories {
     public static final CategoryIdentifier<CookingPotDisplay> COOKING_POT_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "cooking_pot"));
+    public static final CategoryIdentifier<FermentationBarrelDisplay> FERMENTATION_BARREL_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "fermentation_barrel"));
 }

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
@@ -1,0 +1,10 @@
+package com.github.erdragh.astralvinery.compat.rei;
+
+import com.github.erdragh.astralvinery.AstralVinery;
+import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import net.minecraft.util.Identifier;
+
+public class REICategories {
+    public static final CategoryIdentifier<CookingPotDisplay> COOKING_POT_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "cooking_pot"));
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/REICategories.java
@@ -3,10 +3,12 @@ package com.github.erdragh.astralvinery.compat.rei;
 import com.github.erdragh.astralvinery.AstralVinery;
 import com.github.erdragh.astralvinery.compat.rei.cooking_pot.CookingPotDisplay;
 import com.github.erdragh.astralvinery.compat.rei.fermentation_barrel.FermentationBarrelDisplay;
+import com.github.erdragh.astralvinery.compat.rei.wood_fired_oven.WoodFiredOvenDisplay;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import net.minecraft.util.Identifier;
 
 public class REICategories {
     public static final CategoryIdentifier<CookingPotDisplay> COOKING_POT_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "cooking_pot"));
     public static final CategoryIdentifier<FermentationBarrelDisplay> FERMENTATION_BARREL_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "fermentation_barrel"));
+    public static final CategoryIdentifier<WoodFiredOvenDisplay> WOOD_FIRED_OVEN_CATEGORY = CategoryIdentifier.of(new Identifier(AstralVinery.MODID, "wood_fired_oven"));
 }

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/REIUtils.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/REIUtils.java
@@ -1,0 +1,15 @@
+package com.github.erdragh.astralvinery.compat.rei;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class REIUtils {
+    public static List<Ingredient> addIngredient(List<Ingredient> ingredients, ItemStack stack) {
+        var copiedList = new ArrayList<>(ingredients);
+        copiedList.add(0, Ingredient.ofItems(stack.getItem()));
+        return copiedList;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/cooking_pot/CookingPotCategory.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/cooking_pot/CookingPotCategory.java
@@ -1,0 +1,96 @@
+package com.github.erdragh.astralvinery.compat.rei.cooking_pot;
+
+import com.github.erdragh.astralvinery.AstralVinery;
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import com.google.common.collect.Lists;
+import com.mojang.blaze3d.systems.RenderSystem;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import satisfyu.vinery.VineryIdentifier;
+import satisfyu.vinery.block.entity.CookingPotEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Environment(EnvType.CLIENT)
+public class CookingPotCategory implements DisplayCategory<CookingPotDisplay> {
+
+    public static final Identifier ICON = new VineryIdentifier("textures/item/cooking_pot.png");
+    public static final Identifier BG = new VineryIdentifier("textures/gui/pot_gui.png");
+
+    @Override
+    public Renderer getIcon() {
+        return new Renderer() {
+            @Override
+            public void render(MatrixStack matrices, Rectangle bounds, int mouseX, int mouseY, float delta) {
+                RenderSystem.setShaderTexture(0, ICON);
+                DrawableHelper.drawTexture(matrices, bounds.x, bounds.y, 0, 0,16, 16, 16, 16);
+            }
+
+            @Override
+            public int getZ() {
+                return 0;
+            }
+
+            @Override
+            public void setZ(int z) {
+
+            }
+        };
+    }
+    @Override
+    public Text getTitle() {
+        return new TranslatableText("rei.category.astralvinery.cooking_pot");
+    }
+
+    @Override
+    public CategoryIdentifier<? extends CookingPotDisplay> getCategoryIdentifier() {
+        return REICategories.COOKING_POT_CATEGORY;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 60 + 4;
+    }
+
+    @Override
+    public int getDisplayWidth(CookingPotDisplay display) {
+        return 123 + 4;
+    }
+
+    @Override
+    public List<Widget> setupDisplay(CookingPotDisplay display, Rectangle bounds) {
+        Point startPoint = new Point(bounds.getCenterX() - 55, bounds.getCenterY() - 13);
+        List<Widget> widgets = new ArrayList<>();
+        widgets.add(Widgets.createRecipeBase(bounds));
+        //widgets.add(Widgets.createResultSlotBackground(new Point(startPoint.x + 90, startPoint.y)));
+        widgets.add(Widgets.createTexturedWidget(BG, new Rectangle(bounds.x + 4, bounds.y + 4, bounds.width - 8, bounds.height - 8), 29, 16));
+        widgets.add(Widgets.createArrow(new Point(bounds.x + 60 + 4, bounds.y + 10 + 4)).animationDurationTicks(CookingPotEntity.MAX_COOKING_TIME));
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 91, startPoint.y - 3)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+        for(int i = 0; i < 6; i++){
+            int x = i * 18;
+            int y = 5;
+            if(i > 2){
+                x = (i - 3) * 18;
+                y+=18;
+            }
+            x+=5;
+            if(i >= display.getInputEntries().size() - 1) widgets.add(Widgets.createSlotBackground(new Point(bounds.x + x, bounds.y + y)));
+            else widgets.add(Widgets.createSlot(new Point(bounds.x + x, bounds.y + y)).entries(display.getInputEntries().get(i + 1)).markInput());
+        }
+        widgets.add(Widgets.createSlot(new Point(startPoint.x + 59, startPoint.y + 24)).entries(display.getInputEntries().get(0)).markInput());
+        return widgets;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/cooking_pot/CookingPotCategory.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/cooking_pot/CookingPotCategory.java
@@ -11,6 +11,7 @@ import me.shedaniel.rei.api.client.gui.widgets.Widget;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.DrawableHelper;
@@ -20,35 +21,18 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import satisfyu.vinery.VineryIdentifier;
 import satisfyu.vinery.block.entity.CookingPotEntity;
+import satisfyu.vinery.registry.ObjectRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Environment(EnvType.CLIENT)
 public class CookingPotCategory implements DisplayCategory<CookingPotDisplay> {
-
-    public static final Identifier ICON = new VineryIdentifier("textures/item/cooking_pot.png");
     public static final Identifier BG = new VineryIdentifier("textures/gui/pot_gui.png");
 
     @Override
     public Renderer getIcon() {
-        return new Renderer() {
-            @Override
-            public void render(MatrixStack matrices, Rectangle bounds, int mouseX, int mouseY, float delta) {
-                RenderSystem.setShaderTexture(0, ICON);
-                DrawableHelper.drawTexture(matrices, bounds.x, bounds.y, 0, 0,16, 16, 16, 16);
-            }
-
-            @Override
-            public int getZ() {
-                return 0;
-            }
-
-            @Override
-            public void setZ(int z) {
-
-            }
-        };
+        return EntryStacks.of(ObjectRegistry.COOKING_POT);
     }
     @Override
     public Text getTitle() {

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/cooking_pot/CookingPotDisplay.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/cooking_pot/CookingPotDisplay.java
@@ -1,0 +1,30 @@
+package com.github.erdragh.astralvinery.compat.rei.cooking_pot;
+
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import satisfyu.vinery.recipe.CookingPotRecipe;
+
+import java.util.List;
+
+@Environment(EnvType.CLIENT)
+public record CookingPotDisplay(CookingPotRecipe recipe) implements Display {
+    @Override
+    public List<EntryIngredient> getInputEntries() {
+        return EntryIngredients.ofIngredients(recipe.getIngredients());
+    }
+
+    @Override
+    public List<EntryIngredient> getOutputEntries() {
+        return List.of(EntryIngredients.of(recipe.getOutput()));
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return REICategories.COOKING_POT_CATEGORY;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/fermentation_barrel/FermentationBarrelCategory.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/fermentation_barrel/FermentationBarrelCategory.java
@@ -67,11 +67,8 @@ public class FermentationBarrelCategory implements DisplayCategory<FermentationB
                 y += 18;
             }
             x += 4;
-            if (i >= display.getInputEntries().size() - 1)
-                widgets.add(Widgets.createSlotBackground(new Point(withinBorders.x + x, withinBorders.y + y)));
-            else
-                widgets.add(Widgets.createSlot(new Point(withinBorders.x + x, withinBorders.y + y)).entries(display.getInputEntries().get(i + 1)).markInput());
-
+            if (i >= display.getInputEntries().size() - 1) widgets.add(Widgets.createSlotBackground(new Point(withinBorders.x + x, withinBorders.y + y)));
+            else widgets.add(Widgets.createSlot(new Point(withinBorders.x + x, withinBorders.y + y)).entries(display.getInputEntries().get(i + 1)).markInput());
         }
         widgets.add(Widgets.createSlot(new Point(withinBorders.x + 49, withinBorders.y + 34)).entries(display.getInputEntries().get(0)).markInput());
         return widgets;

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/fermentation_barrel/FermentationBarrelCategory.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/fermentation_barrel/FermentationBarrelCategory.java
@@ -1,0 +1,79 @@
+package com.github.erdragh.astralvinery.compat.rei.fermentation_barrel;
+
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import com.google.common.collect.Lists;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import satisfyu.vinery.VineryIdentifier;
+import satisfyu.vinery.block.entity.FermentationBarrelBlockEntity;
+import satisfyu.vinery.registry.ObjectRegistry;
+
+import java.util.List;
+
+@Environment(EnvType.CLIENT)
+public class FermentationBarrelCategory implements DisplayCategory<FermentationBarrelDisplay> {
+    public static final Identifier BG = new VineryIdentifier("textures/gui/barrel_gui.png");
+    private static final int BORDER_WIDTH = 6;
+
+    @Override
+    public CategoryIdentifier<? extends FermentationBarrelDisplay> getCategoryIdentifier() {
+        return REICategories.FERMENTATION_BARREL_CATEGORY;
+    }
+
+    @Override
+    public Text getTitle() {
+        return new TranslatableText("rei.astralvinery.fermentation_barrel");
+    }
+
+    @Override
+    public Renderer getIcon() {
+        return EntryStacks.of(ObjectRegistry.FERMENTATION_BARREL);
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 52 + 2 * BORDER_WIDTH;
+    }
+
+    @Override
+    public int getDisplayWidth(FermentationBarrelDisplay display) {
+        return 129 + 2 * BORDER_WIDTH;
+    }
+
+    @Override
+    public List<Widget> setupDisplay(FermentationBarrelDisplay display, Rectangle bounds) {
+        List<Widget> widgets = Lists.newArrayList();
+        widgets.add(Widgets.createRecipeBase(bounds));
+        widgets.add(Widgets.createTexturedWidget(BG, new Rectangle(bounds.x + BORDER_WIDTH, bounds.y + BORDER_WIDTH, bounds.width - 2 * BORDER_WIDTH, bounds.height - 2 * BORDER_WIDTH), 13, 15));
+        Point withinBorders = new Point(bounds.x + BORDER_WIDTH + 1, bounds.y + BORDER_WIDTH + 1);
+        widgets.add(Widgets.createArrow(new Point(withinBorders.x + 75, withinBorders.y + 18)).animationDurationTicks(FermentationBarrelBlockEntity.COOKING_TIME_IN_TICKS));
+        widgets.add(Widgets.createSlot(new Point(withinBorders.x + 111, withinBorders.y + 19)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+        for (int i = 0; i < 4; i++) {
+            int x = i * 18;
+            int y = 10;
+            if (i > 1) {
+                x = (i - 2) * 18;
+                y += 18;
+            }
+            x += 4;
+            if (i >= display.getInputEntries().size() - 1)
+                widgets.add(Widgets.createSlotBackground(new Point(withinBorders.x + x, withinBorders.y + y)));
+            else
+                widgets.add(Widgets.createSlot(new Point(withinBorders.x + x, withinBorders.y + y)).entries(display.getInputEntries().get(i + 1)).markInput());
+
+        }
+        widgets.add(Widgets.createSlot(new Point(withinBorders.x + 49, withinBorders.y + 34)).entries(display.getInputEntries().get(0)).markInput());
+        return widgets;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/fermentation_barrel/FermentationBarrelDisplay.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/fermentation_barrel/FermentationBarrelDisplay.java
@@ -1,0 +1,38 @@
+package com.github.erdragh.astralvinery.compat.rei.fermentation_barrel;
+
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import com.github.erdragh.astralvinery.compat.rei.REIUtils;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+import satisfyu.vinery.recipe.FermentationBarrelRecipe;
+import satisfyu.vinery.registry.ObjectRegistry;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Environment(EnvType.CLIENT)
+public record FermentationBarrelDisplay(FermentationBarrelRecipe recipe) implements Display {
+
+    @Override
+    public List<EntryIngredient> getInputEntries() {
+        return EntryIngredients.ofIngredients(REIUtils.addIngredient(recipe.getIngredients(), new ItemStack(ObjectRegistry.WINE_BOTTLE)));
+    }
+
+    @Override
+    public List<EntryIngredient> getOutputEntries() {
+        return Collections.singletonList(EntryIngredients.of(recipe.getOutput()));
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return REICategories.FERMENTATION_BARREL_CATEGORY;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/wine_press/WinePressCategory.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/wine_press/WinePressCategory.java
@@ -1,0 +1,66 @@
+package com.github.erdragh.astralvinery.compat.rei.wine_press;
+
+import com.github.erdragh.astralvinery.AstralVinery;
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import com.google.common.collect.Lists;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import satisfyu.vinery.VineryIdentifier;
+import satisfyu.vinery.registry.ObjectRegistry;
+
+import java.util.List;
+
+public class WinePressCategory implements DisplayCategory<WinePressDisplay> {
+
+    private static final Identifier BG = new VineryIdentifier("textures/gui/wine_press.png");
+
+    private static final int BORDER_WIDTH = 6;
+    @Override
+    public CategoryIdentifier<? extends WinePressDisplay> getCategoryIdentifier() {
+        return REICategories.WINE_PRESS_CATEGORY;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 50 + 2 * BORDER_WIDTH;
+    }
+
+    @Override
+    public int getDisplayWidth(WinePressDisplay display) {
+        return 93 + 2 * BORDER_WIDTH;
+    }
+
+    @Override
+    public Text getTitle() {
+        return new TranslatableText("rei." + AstralVinery.MODID + ".wine_press");
+    }
+
+    @Override
+    public Renderer getIcon() {
+        return EntryStacks.of(ObjectRegistry.WINE_PRESS);
+    }
+
+    @Override
+    public List<Widget> setupDisplay(WinePressDisplay display, Rectangle bounds) {
+        List<Widget> widgets = Lists.newArrayList();
+        widgets.add(Widgets.createRecipeBase(bounds));
+
+        var withinBorders = new Rectangle(bounds.x + BORDER_WIDTH, bounds.y + BORDER_WIDTH, bounds.width - 2 * BORDER_WIDTH, bounds.height - 2 * BORDER_WIDTH);
+
+        widgets.add(Widgets.createTexturedWidget(BG, new Rectangle(withinBorders.x, withinBorders.y, withinBorders.width, withinBorders.height), 44, 17));
+
+        widgets.add(Widgets.createSlot(new Point(withinBorders.x + 4, withinBorders.y + 17)).entries(display.getInputEntries().get(0)).markInput());
+        widgets.add(Widgets.createArrow(new Point(withinBorders.x + 34, withinBorders.y + 17)).animationDurationTicks(72));
+        widgets.add(Widgets.createSlot(new Point(withinBorders.x + 72, withinBorders.y + 18)).entries(display.getOutputEntries().get(0)).disableBackground().markOutput());
+        return widgets;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/wine_press/WinePressDisplay.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/wine_press/WinePressDisplay.java
@@ -1,0 +1,30 @@
+package com.github.erdragh.astralvinery.compat.rei.wine_press;
+
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import net.minecraft.item.Items;
+import satisfyu.vinery.registry.ObjectRegistry;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WinePressDisplay implements Display {
+
+    @Override
+    public List<EntryIngredient> getInputEntries() {
+        return Collections.singletonList(EntryIngredients.of(Items.APPLE));
+    }
+
+    @Override
+    public List<EntryIngredient> getOutputEntries() {
+        return Collections.singletonList(EntryIngredients.of(ObjectRegistry.APPLE_MASH));
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return REICategories.WINE_PRESS_CATEGORY;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/wood_fired_oven/WoodFiredOvenCategory.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/wood_fired_oven/WoodFiredOvenCategory.java
@@ -1,0 +1,94 @@
+package com.github.erdragh.astralvinery.compat.rei.wood_fired_oven;
+
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import com.google.common.collect.Lists;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import satisfyu.vinery.VineryIdentifier;
+import satisfyu.vinery.block.entity.WoodFiredOvenBlockEntity;
+import satisfyu.vinery.registry.ObjectRegistry;
+
+import java.text.DecimalFormat;
+import java.util.List;
+
+public class WoodFiredOvenCategory implements DisplayCategory<WoodFiredOvenDisplay> {
+
+    private final Identifier BG = new VineryIdentifier("textures/gui/stove_gui.png");
+
+    private final int BORDER_WIDTH = 6;
+
+    @Override
+    public int getDisplayHeight() {
+        return 49 + 2 * BORDER_WIDTH;
+    }
+
+    @Override
+    public int getDisplayWidth(WoodFiredOvenDisplay display) {
+        return 3 * 18 + 3 + 22 + 3 + 28 + 2 * BORDER_WIDTH;
+    }
+
+    @Override
+    public List<Widget> setupDisplay(WoodFiredOvenDisplay display, Rectangle bounds) {
+        int cookingTime = WoodFiredOvenBlockEntity.TOTAL_COOKING_TIME;
+        List<Widget> widgets = Lists.newArrayList();
+        widgets.add(Widgets.createRecipeBase(bounds));
+        DecimalFormat df = new DecimalFormat("###.##");
+        widgets.add(Widgets.createLabel(new Point(bounds.x + bounds.width - 5, bounds.y + 5), new TranslatableText("category.rei.cooking.time&xp", df.format(display.recipe().getExperience()), df.format(cookingTime / 20d))).noShadow().rightAligned().color(0xFF404040, 0xFFBBBBBB));
+
+        var inputs = display.getInputEntries();
+
+        var withinBorders = new Rectangle(bounds.x + BORDER_WIDTH + 1, bounds.y + BORDER_WIDTH + 1, bounds.width - 2 * BORDER_WIDTH, bounds.height - 2 * BORDER_WIDTH);
+
+        // move down the widgets a bit, so they don't clash with the text above as hard
+        withinBorders.y += 4;
+
+        int leftHeight = 18 + 15;
+        int leftWidth = 3 * 18;
+
+        // centers the widgets on the left vertically
+        var leftBase = new Point(withinBorders.x, withinBorders.y + (withinBorders.height - leftHeight) / 2);
+
+        for (int x = 0; x < 3; x++) {
+            Point p = new Point(leftBase.x + x * 18, leftBase.y);
+            if (inputs.size() > x) {
+                widgets.add(Widgets.createSlot(p).entries(inputs.get(x)).markInput());
+            } else {
+                widgets.add(Widgets.createSlotBackground(p));
+            }
+        }
+
+        widgets.add(Widgets.createBurningFire(new Point(leftBase.x + 1.5 * 18 - 8, leftBase.y + 18)).animationDurationTicks(500));
+
+        // the -2 is done, because the arrow for some reason starts 2 pixels to the right of where its coordinates are
+        widgets.add(Widgets.createArrow(new Point(withinBorders.x + leftWidth + 3 - 2, withinBorders.y + (withinBorders.height - 16) / 2)).animationDurationTicks(cookingTime));
+        widgets.add(Widgets.createTexturedWidget(BG, new Rectangle(withinBorders.x + leftWidth + 3 - 2 + 22 + 3 + 1, withinBorders.y + (withinBorders.height - 26) / 2, 28, 26), 110, 30));
+        widgets.add(Widgets.createSlot(new Point(withinBorders.x + leftWidth + 3 - 2 + 22 + 3 + 7, withinBorders.y + (withinBorders.height - 18) / 2 + 1)).entries(display.getOutputEntries().get(0)).markOutput().disableBackground());
+        return widgets;
+    }
+
+    @Override
+    public CategoryIdentifier<? extends WoodFiredOvenDisplay> getCategoryIdentifier() {
+        return REICategories.WOOD_FIRED_OVEN_CATEGORY;
+    }
+
+    @Override
+    public Text getTitle() {
+        return new TranslatableText("rei.astralvinery.wood_fired_oven");
+    }
+
+    @Override
+    public Renderer getIcon() {
+        return EntryStacks.of(ObjectRegistry.WOOD_FIRED_OVEN);
+    }
+
+
+}

--- a/src/main/java/com/github/erdragh/astralvinery/compat/rei/wood_fired_oven/WoodFiredOvenDisplay.java
+++ b/src/main/java/com/github/erdragh/astralvinery/compat/rei/wood_fired_oven/WoodFiredOvenDisplay.java
@@ -1,0 +1,28 @@
+package com.github.erdragh.astralvinery.compat.rei.wood_fired_oven;
+
+import com.github.erdragh.astralvinery.compat.rei.REICategories;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import satisfyu.vinery.recipe.WoodFiredOvenRecipe;
+
+import java.util.Collections;
+import java.util.List;
+
+public record WoodFiredOvenDisplay(WoodFiredOvenRecipe recipe) implements Display {
+    @Override
+    public List<EntryIngredient> getInputEntries() {
+        return EntryIngredients.ofIngredients(recipe.getIngredients());
+    }
+
+    @Override
+    public List<EntryIngredient> getOutputEntries() {
+        return Collections.singletonList(EntryIngredients.of(recipe.getOutput()));
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return REICategories.WOOD_FIRED_OVEN_CATEGORY;
+    }
+}

--- a/src/main/java/com/github/erdragh/astralvinery/mixin/CookingPotEntityMixin.java
+++ b/src/main/java/com/github/erdragh/astralvinery/mixin/CookingPotEntityMixin.java
@@ -1,0 +1,37 @@
+package com.github.erdragh.astralvinery.mixin;
+
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import satisfyu.vinery.block.entity.CookingPotEntity;
+
+@Mixin(CookingPotEntity.class)
+public abstract class CookingPotEntityMixin implements ExtendedScreenHandlerFactory {
+
+    @Shadow public abstract boolean isBeingBurned();
+
+    @Override
+    public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+        buf.writeBoolean(this.isBeingBurned());
+    }
+
+    @Override
+    @Shadow
+    public Text getDisplayName() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    @Shadow
+    public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
+        return null;
+    }
+}

--- a/src/main/resources/astralvinery.mixins.json
+++ b/src/main/resources/astralvinery.mixins.json
@@ -5,7 +5,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "StorageBlockEntityMixin",
-    "StorageBlockMixin"
+    "StorageBlockMixin",
+    "CookingPotEntityMixin"
   ],
   "client": [
   ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,6 +22,9 @@
     ],
     "main": [
       "com.github.erdragh.astralvinery.AstralVinery"
+    ],
+    "rei_client": [
+      "com.github.erdragh.astralvinery.compat.rei.AstralVineryClientPlugin"
     ]
   },
   "mixins": [


### PR DESCRIPTION
- Fixed cooking pot GUI not opening
- Added REI Integration for Vinery Recipes (Will be removed when eventually updating to 1.19+, as Vinery added its own REI compat in newer versions